### PR TITLE
Switch from X, Y back to Pose(s)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ publishing {
 		register<MavenPublication>("release") {
 			groupId = "com.pedropathing"
 			artifactId = "pedro"
-			version = "1.0.1"
+			version = "1.0.2"
 
 			afterEvaluate {
 				from(components["release"])

--- a/src/main/java/com/pedropathing/localization/constants/ThreeWheelConstants.java
+++ b/src/main/java/com/pedropathing/localization/constants/ThreeWheelConstants.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.constants;
 
 import com.pedropathing.localization.Encoder;
+import com.pedropathing.localization.Pose;
 
 /**
  * This is the ThreeWheelConstants class. It holds many constants and parameters for the Three Wheel Localizer.
@@ -22,17 +23,17 @@ public class ThreeWheelConstants {
      * @value Default Value: .001989436789 */
     public static double turnTicksToInches = .001989436789;
 
-    /** The Y Offset of the Left Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: 1 */
-    public static double leftY = 1;
+    /** The X, Y, and Rotation Offset of the Left Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, 1, 0deg */
+    public static Pose leftEncoderPose = new Pose(0, 1, Math.toRadians(0));
 
-    /** The Y Offset of the Right Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: -1 */
-    public static double rightY = -1;
+    /** The X, Y, and Rotation Offset of the Right Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, -1, 0deg */
+    public static Pose rightEncoderPose = new Pose(0, -1, Math.toRadians(0));
 
-    /** The X Offset of the Strafe Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: -2.5 */
-    public static double strafeX = -2.5;
+    /** The X, Y, and Rotation Offset of the Strafe Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: -2.5, 0, 90deg */
+    public static Pose strafeEncoderPose = new Pose(-2.5, 0, Math.toRadians(90));
 
     /** The name of the Left Encoder in the hardware map (name of the motor port it is plugged into)
      * @value Default Value: "leftFront" */

--- a/src/main/java/com/pedropathing/localization/constants/ThreeWheelIMUConstants.java
+++ b/src/main/java/com/pedropathing/localization/constants/ThreeWheelIMUConstants.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.constants;
 
 import com.pedropathing.localization.Encoder;
+import com.pedropathing.localization.Pose;
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 
 /**
@@ -23,17 +24,17 @@ public class ThreeWheelIMUConstants {
      * @value Default Value: .001989436789 */
     public static double turnTicksToInches = .001989436789;
 
-    /** The Y Offset of the Left Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: 1 */
-    public static double leftY = 1;
+    /** The X, Y, and Rotation Offset of the Left Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, 1, 0deg */
+    public static Pose leftEncoderPose = new Pose(0, 1, Math.toRadians(0));
 
-    /** The Y Offset of the Right Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: -1 */
-    public static double rightY = -1;
+    /** The X, Y, and Rotation Offset of the Right Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, -1, 0deg */
+    public static Pose rightEncoderPose = new Pose(0, -1, Math.toRadians(0));
 
-    /** The X Offset of the Strafe Encoder (Deadwheel) from the center of the robot
-     * @value Default Value: -2.5 */
-    public static double strafeX = -2.5;
+    /** The X, Y, and Rotation Offset of the Strafe Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: -2.5, 0, 90deg */
+    public static Pose strafeEncoderPose = new Pose(-2.5, 0, Math.toRadians(90));
 
     /** The Hardware Map Name of the IMU (built-in IMU will be Port 0, "imu")
      * @value Default Value: "imu" */

--- a/src/main/java/com/pedropathing/localization/constants/TwoWheelConstants.java
+++ b/src/main/java/com/pedropathing/localization/constants/TwoWheelConstants.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.constants;
 
 import com.pedropathing.localization.Encoder;
+import com.pedropathing.localization.Pose;
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 
 /**
@@ -19,13 +20,13 @@ public class TwoWheelConstants {
      * @value Default Value: .001989436789 */
     public static double strafeTicksToInches = .001989436789;
 
-    /** The y offset of the forward encoder (Deadwheel) from the center of the robot
-     * @value Default Value: 1 */
-    public static double forwardY = 1;
+    /** The X, Y, and Rotation Offset of the Forward Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, 1, 0deg */
+    public static Pose forwardEncoderPose = new Pose(0, 1, Math.toRadians(0));
 
-    /** The x offset of the strafe encoder (Deadwheel) from the center of the robot
-     * @value Default Value: -2.5 */
-    public static double strafeX = -2.5;
+    /** The X, Y, and Rotation Offset of the Strafe Encoder (Deadwheel) from the center of the robot
+     * @value Default Value: 0, -2.5, 0deg */
+    public static Pose strafeEncoderPose = new Pose(-2.5, 0, Math.toRadians(90));
 
     /** The Hardware Map Name of the IMU (built-in IMU will be Port 0, "imu")
      * @value Default Value: "imu" */

--- a/src/main/java/com/pedropathing/localization/localizers/ThreeWheelIMULocalizer.java
+++ b/src/main/java/com/pedropathing/localization/localizers/ThreeWheelIMULocalizer.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.localizers;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.pedropathing.localization.constants.ThreeWheelIMUConstants;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;
@@ -94,9 +95,9 @@ public class ThreeWheelIMULocalizer extends Localizer {
         STRAFE_TICKS_TO_INCHES = strafeTicksToInches;
         TURN_TICKS_TO_RADIANS = turnTicksToInches;
 
-        leftEncoderPose = new Pose(0, leftY, 0);
-        rightEncoderPose = new Pose(0, rightY, 0);
-        strafeEncoderPose = new Pose(strafeX, 0, Math.toRadians(90));
+        leftEncoderPose = ThreeWheelIMUConstants.leftEncoderPose;
+        rightEncoderPose = ThreeWheelIMUConstants.rightEncoderPose;
+        strafeEncoderPose = ThreeWheelIMUConstants.strafeEncoderPose;
 
         imu = hardwareMap.get(IMU.class, IMU_HardwareMapName);
         imu.initialize(new IMU.Parameters(IMU_Orientation));

--- a/src/main/java/com/pedropathing/localization/localizers/ThreeWheelLocalizer.java
+++ b/src/main/java/com/pedropathing/localization/localizers/ThreeWheelLocalizer.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.localizers;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.pedropathing.localization.constants.ThreeWheelConstants;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
@@ -84,9 +85,9 @@ public class ThreeWheelLocalizer extends Localizer {
         STRAFE_TICKS_TO_INCHES = strafeTicksToInches;
         TURN_TICKS_TO_RADIANS = turnTicksToInches;
 
-        leftEncoderPose = new Pose(0, leftY, 0);
-        rightEncoderPose = new Pose(0, rightY, 0);
-        strafeEncoderPose = new Pose(strafeX, 0, Math.toRadians(90));
+        leftEncoderPose = ThreeWheelConstants.leftEncoderPose;
+        rightEncoderPose = ThreeWheelConstants.rightEncoderPose;
+        strafeEncoderPose = ThreeWheelConstants.strafeEncoderPose;
 
         leftEncoder = new Encoder(hardwareMap.get(DcMotorEx.class, leftEncoder_HardwareMapName));
         rightEncoder = new Encoder(hardwareMap.get(DcMotorEx.class, rightEncoder_HardwareMapName));

--- a/src/main/java/com/pedropathing/localization/localizers/TwoWheelLocalizer.java
+++ b/src/main/java/com/pedropathing/localization/localizers/TwoWheelLocalizer.java
@@ -1,6 +1,7 @@
 package com.pedropathing.localization.localizers;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.pedropathing.localization.constants.TwoWheelConstants;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;
@@ -84,8 +85,8 @@ public class TwoWheelLocalizer extends Localizer {
         FORWARD_TICKS_TO_INCHES = forwardTicksToInches;
         STRAFE_TICKS_TO_INCHES = strafeTicksToInches;
 
-        forwardEncoderPose = new Pose(0, forwardY, 0);
-        strafeEncoderPose = new Pose(strafeX, 0, Math.toRadians(90));
+        forwardEncoderPose = TwoWheelConstants.forwardEncoderPose;
+        strafeEncoderPose = TwoWheelConstants.strafeEncoderPose;
 
         hardwareMap = map;
 


### PR DESCRIPTION
I think having the encoders as a Pose allow for more customizability & better performance. 
My team also uses it this way, and without it being a Pose we can't use Pedro.

I also bumped the version to 1.0.2 if that's okay.