### PR TITLE
added option to add vision measurements using a Kalman filter

### DIFF
--- a/core/src/main/java/com/pedropathing/math/MathFunctions.java
+++ b/core/src/main/java/com/pedropathing/math/MathFunctions.java
@@ -129,4 +129,13 @@ public class MathFunctions {
         }
         return (n - x1) * (y2 - y1) / (x2 - x1) + y1;
     }
+
+    /** Multiply a 3x3 matrix (row-major) by a 3x1 vector. */
+    public static double[] mat3x3MulVec(double[][] K, double[] v) {
+        double[] out = new double[3];
+        out[0] = K[0][0] * v[0] + K[0][1] * v[1] + K[0][2] * v[2];
+        out[1] = K[1][0] * v[0] + K[1][1] * v[1] + K[1][2] * v[2];
+        out[2] = K[2][0] * v[0] + K[2][1] * v[1] + K[2][2] * v[2];
+        return out;
+    }
 }


### PR DESCRIPTION
this pr adds the ability to fuse the odometry data with vision data from april tags using a simplified Kalman filter

the code and the math in it is based on the wpilib pose estimator
[https://github.com/wpilibsuite/allwpilib/blob/main/wpimath/src/main/java/edu/wpi/first/math/estimator/PoseEstimator.java](url)

made the necessary changes to the pose tracker will add user functions later