### PR TITLE
Modified CustomCurve to allow curves that require data in addition to control points and to fix problem with getClosestPoint.

### DIFF
--- a/core/src/main/java/com/pedropathing/geometry/CustomCurve.java
+++ b/core/src/main/java/com/pedropathing/geometry/CustomCurve.java
@@ -137,18 +137,12 @@ public abstract class CustomCurve implements Curve {
             futureControlPoints.clear();
         }
 
-        generateCurve();
+        initialization();
 
         initialized = true;
         length = approximateLength();
-        initialization();
         initializePanelsDrawingPoints();
     }
-
-    /*
-     * This method can be overridden to generate the custom curve using the control points and
-     */
-    public void generateCurve(){}
 
     /**
      * This creates the Array that holds the Points to draw on Panels.


### PR DESCRIPTION
Reasons for pull request: currently, CustomCurve does not accommodate curves that require and data other than control points to set up. In addition, it fails (at least sometimes) to find the correct closestPoint when attempting to follow the same path a second time. 

Changes to the CustomCurve class, as follows:

1. Add constructors that accept arbitrary data (as an object) that may be required to generate the custom curve (in addition to the control points).
2. Add a generateCurve method (do-nothing by default) that can be overridden to generate the curve. Call this method from the initialize() method, before the call to approximateLength(), since approximateLength() requires that the curve be set up.
3. Add logic and override the default getClosestPoint method so that, each time the initialize() method is called, the initialTValueGuess will get recalculated on the next call to getClosestPoint. This was needed because for some curves, leaving the initialTValueGuess near 1.0 and re-following the curve from the beginning would result in getClosestPoint return a local minimum near the end of the curve rather than the beginning (leading to bizarre behavior).

This modification is backwards compatible. Example of usage of the new functionality: https://gist.github.com/jkenney2/c96153fb42c4d07fad880e309f0112df