### PR TITLE
Add Heading and Translational Lock

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -59,7 +59,7 @@ public class Follower {
     public boolean useDrive = true;
     private Timer zeroVelocityDetectedTimer = null;
     private Runnable resetFollowing = null;
-    private boolean lockHeading = false;
+    private boolean lockX = false, lockY = false, lockHeading = false;
 
     /**
      * This creates a new Follower given a HardwareMap.
@@ -366,7 +366,11 @@ public class Follower {
      * @param offsetHeading the offset heading for field centric control, will face the direction of such heading in radians in the field coordinate system when driving forward
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, boolean isRobotCentric, double offsetHeading) {
-            vectorCalculator.setTeleOpMovementVectors(forward, strafe, lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn, isRobotCentric, offsetHeading);
+            vectorCalculator.setTeleOpMovementVectors(
+                    lockY && forward == 0 ? vectorCalculator.runTranslationalLock(lockX, true).getYComponent() : forward,
+                    lockX && strafe == 0 ? vectorCalculator.runTranslationalLock(true, lockY).getXComponent() : strafe,
+                    lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn,
+                    isRobotCentric, offsetHeading);
     }
 
     /**
@@ -378,7 +382,10 @@ public class Follower {
      * @param offsetHeading the offset heading for field centric control, will face the direction of such heading in radians in the field coordinate system when driving forward
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, double offsetHeading) {
-        vectorCalculator.setTeleOpMovementVectors(forward, strafe, lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn, true, offsetHeading);
+        vectorCalculator.setTeleOpMovementVectors(
+                lockY && forward == 0 ? vectorCalculator.runTranslationalLock(lockX, true).getYComponent() : forward,
+                lockX && strafe == 0 ? vectorCalculator.runTranslationalLock(true, lockY).getXComponent() : strafe,
+                lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn, true, offsetHeading);
     }
 
     /**
@@ -390,7 +397,10 @@ public class Follower {
      * @param isRobotCentric true if robot centric control, false if field centric
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, boolean isRobotCentric) {
-        vectorCalculator.setTeleOpMovementVectors(forward, strafe, lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn, isRobotCentric);
+        vectorCalculator.setTeleOpMovementVectors(
+                lockY && forward == 0 ? vectorCalculator.runTranslationalLock(lockX, true).getYComponent() : forward,
+                lockX && strafe == 0 ? vectorCalculator.runTranslationalLock(true, lockY).getXComponent() : strafe,
+                lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn, isRobotCentric);
     }
 
     /**
@@ -402,7 +412,10 @@ public class Follower {
      * @param turn the turn movement
      */
     public void setTeleOpDrive(double forward, double strafe, double turn) {
-        vectorCalculator.setTeleOpMovementVectors(forward, strafe, lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn);
+        vectorCalculator.setTeleOpMovementVectors(
+                lockY && forward == 0 ? vectorCalculator.runTranslationalLock(lockX, true).getYComponent() : forward,
+                lockX && strafe == 0 ? vectorCalculator.runTranslationalLock(true, lockY).getXComponent() : strafe,
+                lockHeading && turn == 0 ? vectorCalculator.runHeadingLock() : turn);
     }
 
     /** Updates the Mecanum constants */
@@ -1103,15 +1116,17 @@ public class Follower {
     /**
      * This toggles heading and position locking during TeleOp
      */
-    public void teleOpLock() {
-        lockHeading = !lockHeading;
+    public void teleOpLock (boolean x, boolean y, boolean heading) {
+        lockX = x;
+        lockY = y;
+        lockHeading = heading;
 
-        if (lockHeading) {
-            vectorCalculator.updateLockingPose();
-            vectorCalculator.startHeadingLock();
-        }
-        else {
-            vectorCalculator.stopHeadingLock();
-        }
+        if (x || y || heading)  vectorCalculator.updateLockingPose();
+
+        if (x || y)         vectorCalculator.startTranslationalLock();
+        else                vectorCalculator.stopTranslationalLock();
+
+        if (lockHeading)    vectorCalculator.startHeadingLock();
+        else                vectorCalculator.stopHeadingLock();
     }
 }


### PR DESCRIPTION
Reason: Provides an easy addition to defensive play, in the Decode season especially. Provides an easy toggle for translational and heading zero-power locks.
Neither method uses secondary PIDFs.

### Changes:
* Add heading lock using headingPIDF, only when `setTeleOpDrive()` heading power is 0.
* Add translational lock using translationalPIDF, which adapts to x, y, or both powers being 0.