### PR TITLE
Fix driveErrors indexing bug in Kalman filter

### DIFF
--- a/core/src/main/java/com/pedropathing/ErrorCalculator.java
+++ b/core/src/main/java/com/pedropathing/ErrorCalculator.java
@@ -144,7 +144,7 @@ public class ErrorCalculator {
             driveErrors[i] = driveErrors[i + 1];
         }
 
-        driveErrors[1] = driveKalmanFilter.getState();
+        driveErrors[driveErrors.length] = driveKalmanFilter.getState();
 
         return driveKalmanFilter.getState();
     }


### PR DESCRIPTION
This bug fix is mostly "cosmetic".

The Kalman filter buffer is only of length 2, and new data is being written with a constant numerical index of [1].

This is fine so long as the length doesn't change from 2.

The edit corrects the update, so it depends on the length of the buffer.
