### PR TITLE
Stopping distance calculation incorrect when robot drives backward along path can cause unintended full speed behavior

### DIFF
--- a/core/src/main/java/com/pedropathing/ErrorCalculator.java
+++ b/core/src/main/java/com/pedropathing/ErrorCalculator.java
@@ -144,7 +144,7 @@ public class ErrorCalculator {
             driveErrors[i] = driveErrors[i + 1];
         }
 
-        driveErrors[driveErrors.length] = driveKalmanFilter.getState();
+        driveErrors[1] = driveKalmanFilter.getState();
 
         return driveKalmanFilter.getState();
     }


### PR DESCRIPTION
The stopping distance is calculated from robot acceleration and robot heading relative to the path.

The current code uses the normalized path tangent dotted into the normalized heading to get a factor used to select smoothly between forward and strafe maximum velocities.

This dot product becomes negative when the robot more than +/- 90 degrees.

A Math.abs is added to correct this behavior.

Without this correction, the robot may drive at full speed unexpectedly when driving backwards along a path.