### PR TITLE
fix: correct coordinate system conversion in FTCCoordinates and InvertedFTCCoordinates

### DIFF
--- a/ftc/src/main/java/com/pedropathing/ftc/FTCCoordinates.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/FTCCoordinates.java
@@ -1,6 +1,7 @@
 package com.pedropathing.ftc;
 
 import com.pedropathing.geometry.CoordinateSystem;
+import com.pedropathing.geometry.PedroCoordinates;
 import com.pedropathing.geometry.Pose;
 
 /**
@@ -20,8 +21,11 @@ public enum FTCCoordinates implements CoordinateSystem {
      */
     @Override
     public Pose convertFromPedro(Pose pose) {
-        Pose normalizedPose = pose.minus(new Pose(72, 72));
-        return normalizedPose.rotate(-Math.PI / 2, true);
+        // Center the pose (subtract offset without using minus to avoid coordinate conversion issues)
+        Pose centered = new Pose(pose.getX() - 72, pose.getY() - 72, pose.getHeading());
+        Pose rotated = centered.rotate(-Math.PI / 2, true);
+        // Return with FTC coordinate system
+        return new Pose(rotated.getX(), rotated.getY(), rotated.getHeading(), FTCCoordinates.INSTANCE);
     }
 
     /**
@@ -32,7 +36,9 @@ public enum FTCCoordinates implements CoordinateSystem {
      */
     @Override
     public Pose convertToPedro(Pose pose) {
-        Pose rotatedPose = pose.rotate(-Math.PI / 2, true);
-        return rotatedPose.plus(new Pose(72, 72));
+        // Rotate first (inverse rotation of convertFromPedro)
+        Pose rotated = pose.rotate(Math.PI / 2, true);
+        // Add offset and return with Pedro coordinate system
+        return new Pose(rotated.getX() + 72, rotated.getY() + 72, rotated.getHeading(), PedroCoordinates.INSTANCE);
     }
 }

--- a/ftc/src/main/java/com/pedropathing/ftc/InvertedFTCCoordinates.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/InvertedFTCCoordinates.java
@@ -1,11 +1,12 @@
 package com.pedropathing.ftc;
 
 import com.pedropathing.geometry.CoordinateSystem;
+import com.pedropathing.geometry.PedroCoordinates;
 import com.pedropathing.geometry.Pose;
 
 /**
- * An enum that contains the FTC standard coordinate system.
- * This enum implements the {@link CoordinateSystem} interface, which specifies a way to convert to and from FTC standard coordinates.
+ * An enum that contains the Inverted FTC standard coordinate system (for DECODE game).
+ * This enum implements the {@link CoordinateSystem} interface, which specifies a way to convert to and from Inverted FTC standard coordinates.
  *
  * @author BeepBot99
  */
@@ -16,23 +17,28 @@ public enum InvertedFTCCoordinates implements CoordinateSystem {
      * Converts a {@link Pose} to this coordinate system from Pedro coordinates
      *
      * @param pose The {@link Pose} to convert, in the Pedro coordinate system
-     * @return The converted {@link Pose}, in FTC standard coordinates
+     * @return The converted {@link Pose}, in Inverted FTC standard coordinates
      */
     @Override
     public Pose convertFromPedro(Pose pose) {
-        Pose normalizedPose = pose.minus(new Pose(72, 72));
-        return normalizedPose.rotate(Math.PI / 2, true);
+        // Center the pose (subtract offset without using minus to avoid coordinate conversion issues)
+        Pose centered = new Pose(pose.getX() - 72, pose.getY() - 72, pose.getHeading());
+        Pose rotated = centered.rotate(Math.PI / 2, true);
+        // Return with InvertedFTC coordinate system
+        return new Pose(rotated.getX(), rotated.getY(), rotated.getHeading(), InvertedFTCCoordinates.INSTANCE);
     }
 
     /**
      * Converts a {@link Pose} to Pedro coordinates from this coordinate system
      *
-     * @param pose The {@link Pose} to convert, in FTC standard coordinates
+     * @param pose The {@link Pose} to convert, in Inverted FTC standard coordinates
      * @return The converted {@link Pose}, in Pedro coordinate system
      */
     @Override
     public Pose convertToPedro(Pose pose) {
-        Pose rotatedPose = pose.rotate(Math.PI / 2, true);
-        return rotatedPose.plus(new Pose(72, 72));
+        // Rotate first (inverse rotation of convertFromPedro)
+        Pose rotated = pose.rotate(-Math.PI / 2, true);
+        // Add offset and return with Pedro coordinate system
+        return new Pose(rotated.getX() + 72, rotated.getY() + 72, rotated.getHeading(), PedroCoordinates.INSTANCE);
     }
 }


### PR DESCRIPTION
- Fix rotation direction in convertToPedro (use inverse of convertFromPedro rotation)
- Avoid using plus/minus methods which trigger unwanted coordinate conversion
- Set correct coordinate system on returned Pose objects:
  - convertFromPedro now returns FTC/InvertedFTC coordinate system
  - convertToPedro now returns PedroCoordinates