### PR TITLE
Creating and deallocating hundreds of matrices per second (Issue #114)

### DIFF
--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/DriveEncoderLocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/DriveEncoderLocalizer.java
@@ -23,7 +23,9 @@ public class DriveEncoderLocalizer implements Localizer {
     private Pose startPose;
     private Pose displacementPose;
     private Pose currentVelocity;
-    private Matrix prevRotationMatrix;
+    private final Matrix prevRotationMatrix = new Matrix(3,3);
+    private final Matrix returnMatrix = new Matrix(3,1);
+    private final Matrix transformation = new Matrix(3,3);
     private final NanoTimer timer;
     private long deltaTimeNano;
     private final Encoder leftFront;
@@ -126,7 +128,6 @@ public class DriveEncoderLocalizer implements Localizer {
      * @param heading the rotation of the Matrix
      */
     public void setPrevRotationMatrix(double heading) {
-        prevRotationMatrix = new Matrix(3,3);
         prevRotationMatrix.set(0, 0, Math.cos(heading));
         prevRotationMatrix.set(0, 1, -Math.sin(heading));
         prevRotationMatrix.set(1, 0, Math.sin(heading));
@@ -161,7 +162,6 @@ public class DriveEncoderLocalizer implements Localizer {
         Matrix globalDeltas;
         setPrevRotationMatrix(getPose().getHeading());
 
-        Matrix transformation = new Matrix(3,3);
         if (Math.abs(robotDeltas.get(2, 0)) < 0.001) {
             transformation.set(0, 0, 1.0 - (Math.pow(robotDeltas.get(2, 0), 2) / 6.0));
             transformation.set(0, 1, -robotDeltas.get(2, 0) / 2.0);
@@ -211,7 +211,6 @@ public class DriveEncoderLocalizer implements Localizer {
      * @return returns a Matrix containing the robot relative movement.
      */
     public Matrix getRobotDeltas() {
-        Matrix returnMatrix = new Matrix(3,1);
         // x/forward movement
         returnMatrix.set(0,0, FORWARD_TICKS_TO_INCHES * (leftFront.getDeltaPosition() + rightFront.getDeltaPosition() + leftRear.getDeltaPosition() + rightRear.getDeltaPosition()));
         //y/strafe movement

--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/ThreeWheelIMULocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/ThreeWheelIMULocalizer.java
@@ -30,7 +30,9 @@ public class ThreeWheelIMULocalizer implements Localizer {
     private Pose startPose;
     private Pose displacementPose;
     private Pose currentVelocity;
-    private Matrix prevRotationMatrix;
+    private final Matrix prevRotationMatrix = new Matrix(3,3);
+    private final Matrix returnMatrix = new Matrix(3,1);
+    private final Matrix transformation = new Matrix(3,3);
     private final NanoTimer timer;
     private long deltaTimeNano;
     private final Encoder leftEncoder;
@@ -144,7 +146,6 @@ public class ThreeWheelIMULocalizer implements Localizer {
      * @param heading the rotation of the Matrix
      */
     public void setPrevRotationMatrix(double heading) {
-        prevRotationMatrix = new Matrix(3,3);
         prevRotationMatrix.set(0, 0, Math.cos(heading));
         prevRotationMatrix.set(0, 1, -Math.sin(heading));
         prevRotationMatrix.set(1, 0, Math.sin(heading));
@@ -179,7 +180,6 @@ public class ThreeWheelIMULocalizer implements Localizer {
         Matrix globalDeltas;
         setPrevRotationMatrix(getPose().getHeading());
 
-        Matrix transformation = new Matrix(3,3);
         if (Math.abs(robotDeltas.get(2, 0)) < 0.001) {
             transformation.set(0, 0, 1.0 - (Math.pow(robotDeltas.get(2, 0), 2) / 6.0));
             transformation.set(0, 1, -robotDeltas.get(2, 0) / 2.0);
@@ -231,7 +231,6 @@ public class ThreeWheelIMULocalizer implements Localizer {
      * @return returns a Matrix containing the robot relative movement.
      */
     public Matrix getRobotDeltas() {
-        Matrix returnMatrix = new Matrix(3,1);
         // x/forward movement
         returnMatrix.set(0,0, FORWARD_TICKS_TO_INCHES * (rightEncoder.getDeltaPosition() * leftEncoderPose.getY() - leftEncoder.getDeltaPosition() * rightEncoderPose.getY()) / (leftEncoderPose.getY() - rightEncoderPose.getY()));
         //y/strafe movement

--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/ThreeWheelLocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/ThreeWheelLocalizer.java
@@ -23,7 +23,9 @@ public class ThreeWheelLocalizer implements Localizer {
     private Pose startPose;
     private Pose displacementPose;
     private Pose currentVelocity;
-    private Matrix prevRotationMatrix;
+    private final Matrix prevRotationMatrix = new Matrix(3,3);
+    private final Matrix returnMatrix = new Matrix(3,1);
+    private final Matrix transformation = new Matrix(3,3);
     private final NanoTimer timer;
     private long deltaTimeNano;
     private final Encoder leftEncoder;
@@ -128,7 +130,6 @@ public class ThreeWheelLocalizer implements Localizer {
      * @param heading the rotation of the Matrix
      */
     public void setPrevRotationMatrix(double heading) {
-        prevRotationMatrix = new Matrix(3,3);
         prevRotationMatrix.set(0, 0, Math.cos(heading));
         prevRotationMatrix.set(0, 1, -Math.sin(heading));
         prevRotationMatrix.set(1, 0, Math.sin(heading));
@@ -163,7 +164,6 @@ public class ThreeWheelLocalizer implements Localizer {
         Matrix globalDeltas;
         setPrevRotationMatrix(getPose().getHeading());
 
-        Matrix transformation = new Matrix(3,3);
         if (Math.abs(robotDeltas.get(2, 0)) < 0.001) {
             transformation.set(0, 0, 1.0 - (Math.pow(robotDeltas.get(2, 0), 2) / 6.0));
             transformation.set(0, 1, -robotDeltas.get(2, 0) / 2.0);
@@ -211,7 +211,6 @@ public class ThreeWheelLocalizer implements Localizer {
      * @return returns a Matrix containing the robot relative movement.
      */
     public Matrix getRobotDeltas() {
-        Matrix returnMatrix = new Matrix(3,1);
         // x/forward movement
         returnMatrix.set(0,0, FORWARD_TICKS_TO_INCHES * (rightEncoder.getDeltaPosition() * leftEncoderPose.getY() - leftEncoder.getDeltaPosition() * rightEncoderPose.getY()) / (leftEncoderPose.getY() - rightEncoderPose.getY()));
         //y/strafe movement

--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/TwoWheelLocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/TwoWheelLocalizer.java
@@ -27,7 +27,9 @@ public class TwoWheelLocalizer implements Localizer {
     private Pose startPose;
     private Pose displacementPose;
     private Pose currentVelocity;
-    private Matrix prevRotationMatrix;
+    private final Matrix prevRotationMatrix = new Matrix(3,3);
+    private final Matrix returnMatrix = new Matrix(3,1);
+    private final Matrix transformation = new Matrix(3,3);
     private final NanoTimer timer;
     private long deltaTimeNano;
     private final Encoder forwardEncoder;
@@ -129,7 +131,6 @@ public class TwoWheelLocalizer implements Localizer {
      * @param heading the rotation of the Matrix
      */
     public void setPrevRotationMatrix(double heading) {
-        prevRotationMatrix = new Matrix(3,3);
         prevRotationMatrix.set(0, 0, Math.cos(heading));
         prevRotationMatrix.set(0, 1, -Math.sin(heading));
         prevRotationMatrix.set(1, 0, Math.sin(heading));
@@ -164,7 +165,6 @@ public class TwoWheelLocalizer implements Localizer {
         Matrix globalDeltas;
         setPrevRotationMatrix(getPose().getHeading());
 
-        Matrix transformation = new Matrix(3,3);
         if (Math.abs(robotDeltas.get(2, 0)) < 0.001) {
             transformation.set(0, 0, 1.0 - (Math.pow(robotDeltas.get(2, 0), 2) / 6.0));
             transformation.set(0, 1, -robotDeltas.get(2, 0) / 2.0);
@@ -214,7 +214,6 @@ public class TwoWheelLocalizer implements Localizer {
      * @return returns a Matrix containing the robot relative movement.
      */
     public Matrix getRobotDeltas() {
-        Matrix returnMatrix = new Matrix(3,1);
         // x/forward movement
         returnMatrix.set(0,0, FORWARD_TICKS_TO_INCHES * forwardEncoder.getDeltaPosition() - forwardPodY * deltaRadians);
         //y/strafe movement


### PR DESCRIPTION
PR for #114

This moves the matrices for the three PedroPathing localizers `ThreeWheelLocalizer.java`, `TwoWheelLocalizer.java`, `DriveEncoderLocalizer.java` to the class level, rather than creating and deallocating hundreds of matrices per second.