### PR TITLE
Return true at Follower.atParametricEnd() when no path is set (null)

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -644,10 +644,10 @@ public class Follower {
      * @return returns whether the Follower is at the parametric end of its Path.
      */
     public boolean atParametricEnd() {
-        if(currentPath == null){
+        if (currentPath == null){
             return true;
         }
-        
+
         if (followingPathChain) {
             if (chainIndex == currentPathChain.size() - 1) return currentPath.isAtParametricEnd();
             return false;


### PR DESCRIPTION
Resolves #122