### PR TITLE
New path skipping condition

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -529,13 +529,12 @@ public class Follower {
             zeroVelocityDetectedTimer = new Timer();
         }
         
-        boolean skipToNextPath =
-            followingPathChain && chainIndex < currentPathChain.size() - 2 && usePredictiveBraking
-                && vectorCalculator.predictiveBrakingController
-                .computeOutput(getDistanceRemaining(), getTangentialVelocity()) < 1;
+        boolean nextPathWithinBrakingDistance =
+            followingPathChain && chainIndex < currentPathChain.size() - 1 && usePredictiveBraking
+                && vectorCalculator.driveVector.dot(getClosestPointTangentVector()) < 1;
         
-        if (//!skipToNextPath &&
-            !(currentPath.isAtParametricEnd()
+        if (!(currentPath.isAtParametricEnd()
+              //|| nextPathWithinBrakingDistance
                 || (zeroVelocityDetectedTimer != null
                 && zeroVelocityDetectedTimer.getElapsedTime() > 500.0))) {
             return;


### PR DESCRIPTION
Saved recomputation by simply getting the driveVector.
 currentPathChain.size() - 2 I believe should be -1.
It is still commented out, so it doesn't break anything, but someone should test to see if it works now.