### PR TITLE
Fix Follower.isRobotStuck() method 

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -525,7 +525,7 @@ public class Follower {
             drivetrain.runDrive(getCorrectiveVector(), getHeadingVector(), getDriveVector(), poseTracker.getPose().getHeading(), getVelocity());
         }
 
-        if (poseTracker.getVelocity().getMagnitude() < constants.stuckVelocity && currentPath.getClosestPointTValue() > constants.stuckTValue && zeroVelocityDetectedTimer == null && isBusy) {
+        if (poseTracker.getVelocity().getMagnitude() < constants.stuckVelocity && zeroVelocityDetectedTimer == null && isBusy) {
             zeroVelocityDetectedTimer = new Timer();
         }
         

--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -525,7 +525,8 @@ public class Follower {
             drivetrain.runDrive(getCorrectiveVector(), getHeadingVector(), getDriveVector(), poseTracker.getPose().getHeading(), getVelocity());
         }
 
-        if (poseTracker.getVelocity().getMagnitude() < constants.stuckVelocity && zeroVelocityDetectedTimer == null && isBusy) {
+        if (poseTracker.getVelocity().getMagnitude() < constants.stuckVelocity && zeroVelocityDetectedTimer == null && isBusy &&
+               currentPath.getClosestPointTValue() > constants.stuckTValueLow && currentPath.getClosestPointTValue() < constants.stuckTValueHigh) {
             zeroVelocityDetectedTimer = new Timer();
         }
         

--- a/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
+++ b/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
@@ -233,6 +233,20 @@ public class FollowerConstants {
      * Default Value: 1.0
      */
     public double stuckVelocity = 1.0;
+
+    /**
+     * If the t value is below this, the robot can't be considered stuck (still accelerating)
+     * 
+     * Default Value: 0.8
+     */
+    public double stuckTValueLow = 0.1;
+
+    /**
+     * If the t value is above this, the robot can't be considered stuck (decelerating)
+     * 
+     * Default Value: 0.8
+     */
+    public double stuckTValueHigh = 0.1;
     
     /**
      * The time in ms the robot must be stuck before the path is considered complete.
@@ -373,8 +387,13 @@ public class FollowerConstants {
         return this;
     }
 
-    public FollowerConstants stuckTValue(double stuckTValue) {
-        this.stuckTValue = stuckTValue;
+    public FollowerConstants stuckTValueLow(double stuckTValueLow) {
+        this.stuckTValueLow = stuckTValueLow;
+        return this;
+    }
+
+    public FollowerConstants stuckTValueHigh(double stuckTValueHigh) {
+        this.stuckTValueHigh = stuckTValueHigh;
         return this;
     }
 

--- a/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
+++ b/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
@@ -237,7 +237,7 @@ public class FollowerConstants {
     /**
      * If the t value is below this, the robot can't be considered stuck (still accelerating)
      * 
-     * Default Value: 0.8
+     * Default Value: 0.1
      */
     public double stuckTValueLow = 0.1;
 
@@ -246,7 +246,7 @@ public class FollowerConstants {
      * 
      * Default Value: 0.8
      */
-    public double stuckTValueHigh = 0.1;
+    public double stuckTValueHigh = 0.8;
     
     /**
      * The time in ms the robot must be stuck before the path is considered complete.

--- a/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
+++ b/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
@@ -233,15 +233,7 @@ public class FollowerConstants {
      * Default Value: 1.0
      */
     public double stuckVelocity = 1.0;
-
-    /**
-     * The t-value threshold for stuck detection. If the robot is below this t-value on the path,
-     * stuck detection will not trigger.
-     * 
-     * Default Value: 0.8
-     */
-    public double stuckTValue = 0.8;
-
+    
     /**
      * The time in ms the robot must be stuck before the path is considered complete.
      * Default Value: 500.0


### PR DESCRIPTION
Modified the zero velocity detection logic in Follower.java. `currentPath.getClosestPointTValue() > constants.stuckTValue` has been replaced with 2 proper checks for min and max t values.