### PR TITLE
Allow reusing lazily generated paths

### DIFF
--- a/core/src/main/java/com/pedropathing/geometry/BezierCurve.java
+++ b/core/src/main/java/com/pedropathing/geometry/BezierCurve.java
@@ -132,14 +132,15 @@ public class BezierCurve implements Curve {
      */
     public void initialize() {
         if (initialized && !lazyInitialize) return; // If already initialized, do nothing
-        if (controlPoints.isEmpty() && !futureControlPoints.isEmpty()) {
+        if (lazyInitialize && !futureControlPoints.isEmpty()) {
+            controlPoints.clear();
             for (FuturePose pose : futureControlPoints) {
                 controlPoints.add(pose.getPose());
             }
-            futureControlPoints.clear();
         }
         initialized = true;
         generateBezierCurve();
+        completionMap = new NumericBijectiveMap();
         length = approximateLength();
         endTangent.setOrthogonalComponents(controlPoints.get(controlPoints.size()-1).getX()-controlPoints.get(controlPoints.size()-2).getX(),
                 controlPoints.get(controlPoints.size()-1).getY()-controlPoints.get(controlPoints.size()-2).getY());

--- a/core/src/main/java/com/pedropathing/geometry/BezierLine.java
+++ b/core/src/main/java/com/pedropathing/geometry/BezierLine.java
@@ -239,14 +239,10 @@ public class BezierLine extends BezierCurve {
 
     @Override
     public void initialize() {
-        if (initialized) return;
-        if ((startPoint == null || endPoint == null) && !futureControlPoints.isEmpty()) {
-            if (startPoint == null) {
-                startPoint = futureControlPoints.get(0).getPose();
-            }
-            if (endPoint == null) {
-                endPoint = futureControlPoints.get(1).getPose();
-            }
+        if (initialized && !lazyInitialize) return; // If already initialized, do nothing
+        if (lazyInitialize && !futureControlPoints.isEmpty()) {
+            startPoint = futureControlPoints.get(0).getPose();
+            endPoint = futureControlPoints.get(1).getPose();
         }
         initialized = true;
         length = approximateLength();

--- a/core/src/main/java/com/pedropathing/geometry/BezierPoint.java
+++ b/core/src/main/java/com/pedropathing/geometry/BezierPoint.java
@@ -249,9 +249,11 @@ public class BezierPoint extends BezierCurve {
 
     @Override
     public void initialize() {
-        if (initialized) return;
+        if (initialized && !lazyInitialize) return; // If already initialized, do nothing
+        if (lazyInitialize && !futureControlPoints.isEmpty()) {
+            pose = futureControlPoints.get(0).getPose();
+        }
         initialized = true;
-        if (pose == null && !futureControlPoints.isEmpty()) pose = futureControlPoints.get(0).getPose();
         length = approximateLength();
         super.initializePanelsDrawingPoints();
     }


### PR DESCRIPTION
This PR resolves an issue where lazily generated paths could not be reused more than once. This was allegedly fixed in [v2.0.5](https://github.com/Pedro-Pathing/PedroPathing/releases/tag/v2.0.5), but it still didn't work properly.

This fix ensures that all FuturePoses get fetched every time the path is initialized or run.

**Tested on our robot (23644) and working properly**