### PR TITLE
Add a mirror method for paths

### DIFF
--- a/core/src/main/java/com/pedropathing/paths/HeadingInterpolator.java
+++ b/core/src/main/java/com/pedropathing/paths/HeadingInterpolator.java
@@ -113,6 +113,11 @@ public interface HeadingInterpolator {
                 inner = generator.get();
                 inner.init();
             }
+
+            @Override
+            public HeadingInterpolator mirror() {
+                return lazy(() -> generator.get().mirror());
+            }
         };
     }
 
@@ -131,6 +136,11 @@ public interface HeadingInterpolator {
             public void init() {
                 outer.init();
             }
+
+            @Override
+            public HeadingInterpolator mirror() {
+                return outer.mirror().offset(-offsetRad);
+            }
         };
     }
     
@@ -145,6 +155,29 @@ public interface HeadingInterpolator {
             @Override
             public double interpolate(PathPoint closestPoint) {
                 return MathFunctions.normalizeAngle(outer.interpolate(closestPoint) + Math.PI);
+            }
+
+            @Override
+            public void init() {
+                outer.init();
+            }
+
+            @Override
+            public HeadingInterpolator mirror() {
+                return outer.mirror().reverse();
+            }
+        };
+    }
+
+    /**
+     * Mirrors the heading produced by this interpolator.
+     */
+    default HeadingInterpolator mirror() {
+        HeadingInterpolator outer = this;
+        return new HeadingInterpolator() {
+            @Override
+            public double interpolate(PathPoint closestPoint) {
+                return MathFunctions.normalizeAngle(Math.PI - outer.interpolate(closestPoint));
             }
 
             @Override
@@ -218,10 +251,21 @@ public interface HeadingInterpolator {
      * The robot will always be facing the given point while following the path.
      */
     static HeadingInterpolator facingPoint(double x, double y) {
-        return closestPoint -> MathFunctions.normalizeAngle(Math.atan2(
-            y - closestPoint.pose.getY(),
-            x - closestPoint.pose.getX()
-        ));
+        return new HeadingInterpolator() {
+            @Override
+            public double interpolate(PathPoint closestPoint) {
+                return MathFunctions.normalizeAngle(Math.atan2(
+                        y - closestPoint.pose.getY(),
+                        x - closestPoint.pose.getX()
+                ));
+            }
+
+            @Override
+            public HeadingInterpolator mirror() {
+                Pose mirroredTarget = new Pose(x, y).mirror();
+                return facingPoint(mirroredTarget.getX(), mirroredTarget.getY());
+            }
+        };
     }
 
     /**
@@ -262,6 +306,19 @@ public interface HeadingInterpolator {
             @Override
             public void init() {
                 for (PiecewiseNode node : nodes) node.interpolator.init();
+            }
+
+            @Override
+            public HeadingInterpolator mirror() {
+                PiecewiseNode[] mirroredNodes = new PiecewiseNode[nodes.length];
+                for (int i = 0; i < nodes.length; i++) {
+                    mirroredNodes[i] = new PiecewiseNode(
+                            nodes[i].getInitialTValue(),
+                            nodes[i].getFinalTValue(),
+                            nodes[i].getInterpolator().mirror()
+                    );
+                }
+                return piecewise(mirroredNodes);
             }
         };
     }

--- a/core/src/main/java/com/pedropathing/paths/Path.java
+++ b/core/src/main/java/com/pedropathing/paths/Path.java
@@ -1,6 +1,7 @@
 package com.pedropathing.paths;
 
 import com.pedropathing.geometry.BezierCurve;
+import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Curve;
 import com.pedropathing.geometry.Pose;
 import com.pedropathing.math.Vector;
@@ -685,5 +686,33 @@ public class Path {
     
     public Vector getClosestLeftGradientVector() {
         return curve.leftGradient(closestPointTValue).normalize();
+    }
+
+    /**
+     * Returns a new Path mirrored across the field (default length of 141.5 inches) in Pedro coordinates.
+     */
+    public Path mirror() {
+        return mirror(141.5);
+    }
+
+    /**
+     * Returns a new Path mirrored across the field in Pedro coordinates.
+     *
+     * @param fieldLength distance from one end of the field to the other along the x-axis.
+     */
+    public Path mirror(double fieldLength) {
+        ArrayList<Pose> original = getControlPoints();
+        Pose[] mirrored = new Pose[original.size()];
+        for (int i = 0; i < original.size(); i++) {
+            mirrored[i] = original.get(i).mirror(fieldLength);
+        }
+
+        Curve mirroredCurve = mirrored.length == 2
+                ? new BezierLine(mirrored[0], mirrored[1])
+                : new BezierCurve(mirrored);
+
+        Path result = new Path(mirroredCurve, constraints.copy());
+        result.setHeadingInterpolation(headingInterpolator.mirror());
+        return result;
     }
 }

--- a/core/src/main/java/com/pedropathing/paths/PathChain.java
+++ b/core/src/main/java/com/pedropathing/paths/PathChain.java
@@ -453,4 +453,32 @@ public class PathChain {
 
         return nextCallbacks;
     }
+
+    /**
+     * Returns a new PathChain mirrored across the field (default length of 141.5 inches) in Pedro coordinates.
+     */
+    public PathChain mirror() {
+        return mirror(141.5);
+    }
+
+    /**
+     * Returns a new PathChain mirrored across the field in Pedro coordinates.
+     *
+     * @param fieldLength distance from one end of the field to the other along the x-axis.
+     */
+    public PathChain mirror(double fieldLength) {
+        Path[] mirroredPaths = new Path[pathChain.size()];
+        for (int i = 0; i < pathChain.size(); i++) {
+            mirroredPaths[i] = pathChain.get(i).mirror(fieldLength);
+        }
+
+        PathChain mirrored = new PathChain(mirroredPaths);
+        mirrored.setDecelerationType(decelerationType);
+
+        if (headingInterpolator != null) {
+            mirrored.setHeadingInterpolator(headingInterpolator.mirror());
+        }
+
+        return mirrored;
+    }
 }


### PR DESCRIPTION
This PR adds a `mirror()` method to Path, PathChain, and HeadingInterpolator. This allows you to call `mirror()` once on a path instead of manually mirroring each pose and heading.

**Tested on our robot (23644) and working properly**