### PR TITLE
Add automatic position holding when joysticks are idle

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -65,6 +65,11 @@ public class Follower {
     private Timer zeroVelocityDetectedTimer = null;
     private Runnable resetFollowing = null;
     private Queue<PathCallback> currentCallbacks;
+    private boolean teleOpAutoHoldEnabled = false;
+    private boolean teleOpBrakeMode = true;
+    private double teleOpRawForward = 0;
+    private double teleOpRawStrafe = 0;
+    private double teleOpRawTurn = 0;
 
     /**
      * This creates a new Follower given a HardwareMap.
@@ -389,6 +394,22 @@ public class Follower {
         drivetrain.startTeleopDrive(useBrakeMode);
     }
 
+    /**
+     * This starts teleop drive control.
+     */
+    public void startTeleopDrive(boolean useBrakeMode, boolean holdPosition) {
+        breakFollowing();
+        manualDrive = true;
+        teleOpAutoHoldEnabled = holdPosition;
+        teleOpBrakeMode = useBrakeMode;
+        update();
+        drivetrain.startTeleopDrive(useBrakeMode);
+    }
+
+    public void startTeleOpDrive(boolean useBrakeMode, boolean holdPosition) {
+        startTeleopDrive(useBrakeMode, holdPosition);
+    }
+
     public void startTeleOpDrive(boolean useBrakeMode) {
         startTeleopDrive(useBrakeMode);
     }
@@ -407,6 +428,9 @@ public class Follower {
      * @param offsetHeading the offset heading for field centric control, will face the direction of such heading in radians in the field coordinate system when driving forward
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, boolean isRobotCentric, double offsetHeading) {
+        teleOpRawForward = forward;
+        teleOpRawStrafe = strafe;
+        teleOpRawTurn = turn;
         vectorCalculator.setTeleOpMovementVectors(forward, strafe, turn, isRobotCentric, offsetHeading);
     }
 
@@ -419,6 +443,9 @@ public class Follower {
      * @param offsetHeading the offset heading for field centric control, will face the direction of such heading in radians in the field coordinate system when driving forward
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, double offsetHeading) {
+        teleOpRawForward = forward;
+        teleOpRawStrafe = strafe;
+        teleOpRawTurn = turn;
         vectorCalculator.setTeleOpMovementVectors(forward, strafe, turn, true, offsetHeading);
     }
 
@@ -431,6 +458,9 @@ public class Follower {
      * @param isRobotCentric true if robot centric control, false if field centric
      */
     public void setTeleOpDrive(double forward, double strafe, double turn, boolean isRobotCentric) {
+        teleOpRawForward = forward;
+        teleOpRawStrafe = strafe;
+        teleOpRawTurn = turn;
         vectorCalculator.setTeleOpMovementVectors(forward, strafe, turn, isRobotCentric);
     }
 
@@ -443,6 +473,9 @@ public class Follower {
      * @param turn the turn movement
      */
     public void setTeleOpDrive(double forward, double strafe, double turn) {
+        teleOpRawForward = forward;
+        teleOpRawStrafe = strafe;
+        teleOpRawTurn = turn;
         vectorCalculator.setTeleOpMovementVectors(forward, strafe, turn);
     }
 
@@ -489,8 +522,44 @@ public class Follower {
         updatePose();
         updateDrivetrain();
 
+        if (teleOpAutoHoldEnabled && holdingPosition) {
+            boolean hasInput = Math.abs(teleOpRawForward) > constants.holdInputThreshold
+                    || Math.abs(teleOpRawStrafe) > constants.holdInputThreshold
+                    || Math.abs(teleOpRawTurn) > constants.holdInputThreshold;
+
+            if (hasInput) {
+                boolean savedBrakeMode = teleOpBrakeMode;
+
+                breakFollowing();
+                manualDrive = true;
+                drivetrain.startTeleopDrive(savedBrakeMode);
+
+                teleOpAutoHoldEnabled = true;
+                teleOpBrakeMode = savedBrakeMode;
+
+                // Re-populate vectors wiped by breakFollowing() so motors respond this frame
+                vectorCalculator.setTeleOpMovementVectors(teleOpRawForward, teleOpRawStrafe, teleOpRawTurn);
+            }
+        }
 
         if (manualDrive) {
+            if (teleOpAutoHoldEnabled) {
+                boolean hasInput = Math.abs(teleOpRawForward) > constants.holdInputThreshold
+                        || Math.abs(teleOpRawStrafe) > constants.holdInputThreshold
+                        || Math.abs(teleOpRawTurn) > constants.holdInputThreshold;
+
+                if (!hasInput && getVelocity().getMagnitude() < constants.holdVelocityThreshold) {
+                    boolean savedBrakeMode = teleOpBrakeMode;
+
+                    holdPoint(getPose());
+
+                    teleOpAutoHoldEnabled = true;
+                    teleOpBrakeMode = savedBrakeMode;
+                    manualDrive = false;
+                    return;
+                }
+            }
+
             previousClosestPose = closestPose;
             closestPose = new PathPoint();
             updateErrorAndVectors();
@@ -616,6 +685,7 @@ public class Follower {
         isTurning = false;
         reachedParametricPathEnd = false;
         zeroVelocityDetectedTimer = null;
+        teleOpAutoHoldEnabled = false;
     }
 
     /**

--- a/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
+++ b/core/src/main/java/com/pedropathing/follower/FollowerConstants.java
@@ -249,6 +249,18 @@ public class FollowerConstants {
      */
     public double stuckTimeout = 500.0;
 
+    /** The velocity threshold for TeleOp auto-hold. If the driver is not giving
+     * any input and the robot's velocity drops below this value, the auto-hold feature will engage (if enabled).
+     * Default Value: 0.2
+     */
+    public double holdVelocityThreshold = 0.2;
+
+    /** The input threshold for TeleOp auto-hold. If the magnitude of the driver's
+     * joystick input drops below this value, the robot will consider itself to have "no input".
+     * Default Value: 0.1
+     */
+    public double holdInputThreshold = 0.1;
+
     public FollowerConstants() {
         defaults();
     }


### PR DESCRIPTION
This PR adds an optional feature to `startTeleOpDrive()` that automatically holds the robot's current position using `holdPoint` when no joystick input is detected.

This allows the robot to actively resist external forces (e.g., defense from other robots) when the driver stops moving.

**Tested on our robot (23644) and working properly**