### PR TITLE
Add a resetIMU option to FollowerBuilder for pose continuity

### DIFF
--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -72,13 +72,13 @@ public class Follower {
      * @param localizer Localizer to use
      * @param drivetrain Drivetrain to use
      * @param pathConstraints PathConstraints to use
-     * @param resetIMU whether to reset the IMU or not (if applicable)
+     * @param resetIMUOnInit whether to reset the IMU or not (if applicable)
      */
-    public Follower(FollowerConstants constants, Localizer localizer, Drivetrain drivetrain, PathConstraints pathConstraints, boolean resetIMU) {
+    public Follower(FollowerConstants constants, Localizer localizer, Drivetrain drivetrain, PathConstraints pathConstraints, boolean resetIMUOnInit) {
         this.constants = constants;
         this.pathConstraints = pathConstraints;
 
-        poseTracker = new PoseTracker(localizer, resetIMU);
+        poseTracker = new PoseTracker(localizer, resetIMUOnInit);
         errorCalculator = new ErrorCalculator(constants);
         vectorCalculator = new VectorCalculator(constants);
         this.drivetrain = drivetrain;

--- a/core/src/main/java/com/pedropathing/follower/Follower.java
+++ b/core/src/main/java/com/pedropathing/follower/Follower.java
@@ -72,12 +72,13 @@ public class Follower {
      * @param localizer Localizer to use
      * @param drivetrain Drivetrain to use
      * @param pathConstraints PathConstraints to use
+     * @param resetIMU whether to reset the IMU or not (if applicable)
      */
-    public Follower(FollowerConstants constants, Localizer localizer, Drivetrain drivetrain, PathConstraints pathConstraints) {
+    public Follower(FollowerConstants constants, Localizer localizer, Drivetrain drivetrain, PathConstraints pathConstraints, boolean resetIMU) {
         this.constants = constants;
         this.pathConstraints = pathConstraints;
 
-        poseTracker = new PoseTracker(localizer);
+        poseTracker = new PoseTracker(localizer, resetIMU);
         errorCalculator = new ErrorCalculator(constants);
         vectorCalculator = new VectorCalculator(constants);
         this.drivetrain = drivetrain;
@@ -112,7 +113,7 @@ public class Follower {
      * @param drivetrain Drivetrain to use
      */
     public Follower(FollowerConstants constants, Localizer localizer, Drivetrain drivetrain) {
-        this(constants, localizer, drivetrain, PathConstraints.defaultConstraints);
+        this(constants, localizer, drivetrain, PathConstraints.defaultConstraints, true);
     }
 
     public void setCentripetalScaling(double set) {

--- a/core/src/main/java/com/pedropathing/localization/PoseTracker.java
+++ b/core/src/main/java/com/pedropathing/localization/PoseTracker.java
@@ -41,16 +41,16 @@ public class PoseTracker {
      * Creates a new PoseTracker from a Localizer.
      *
      * @param localizer the Localizer
-     * @param resetIMU whether to reset the IMU or not (if applicable)
+     * @param resetIMUOnInit whether to reset the IMU or not (if applicable)
      */
-    public PoseTracker(Localizer localizer, boolean resetIMU) {
+    public PoseTracker(Localizer localizer, boolean resetIMUOnInit) {
         this.localizer = localizer;
 
-        if (resetIMU) {
+        if (resetIMUOnInit) {
             try {
                 localizer.resetIMU();
             } catch (InterruptedException ignored) {
-                System.out.println("PoseTracker: resetIMU() interrupted");
+                System.out.println("PoseTracker: resetIMUOnInit() interrupted");
             }
         }
     }

--- a/core/src/main/java/com/pedropathing/localization/PoseTracker.java
+++ b/core/src/main/java/com/pedropathing/localization/PoseTracker.java
@@ -41,14 +41,17 @@ public class PoseTracker {
      * Creates a new PoseTracker from a Localizer.
      *
      * @param localizer the Localizer
+     * @param resetIMU whether to reset the IMU or not (if applicable)
      */
-    public PoseTracker(Localizer localizer) {
+    public PoseTracker(Localizer localizer, boolean resetIMU) {
         this.localizer = localizer;
 
-        try {
-            localizer.resetIMU();
-        } catch (InterruptedException ignored) {
-            System.out.println("PoseTracker: resetIMU() interrupted");
+        if (resetIMU) {
+            try {
+                localizer.resetIMU();
+            } catch (InterruptedException ignored) {
+                System.out.println("PoseTracker: resetIMU() interrupted");
+            }
         }
     }
 

--- a/ftc/src/main/java/com/pedropathing/ftc/FollowerBuilder.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/FollowerBuilder.java
@@ -20,6 +20,7 @@ import com.pedropathing.ftc.localization.localizers.TwoWheelLocalizer;
 import com.pedropathing.localization.Localizer;
 import com.pedropathing.paths.PathConstraints;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import java.util.function.Supplier;
 
 /** This is the FollowerBuilder.
  * It is used to create Followers with a specific drivetrain + localizer without having to use a full constructor
@@ -30,8 +31,9 @@ public class FollowerBuilder {
     private final FollowerConstants constants;
     private PathConstraints constraints;
     private final HardwareMap hardwareMap;
-    private Localizer localizer;
+    private Supplier<Localizer> localizerSupplier;
     private Drivetrain drivetrain;
+    private boolean resetIMU = true;
 
     public FollowerBuilder(FollowerConstants constants, HardwareMap hardwareMap) {
         this.constants = constants;
@@ -40,36 +42,43 @@ public class FollowerBuilder {
     }
 
     public FollowerBuilder setLocalizer(Localizer localizer) {
-        this.localizer = localizer;
+        this.localizerSupplier = () -> localizer;
         return this;
     }
 
     public FollowerBuilder driveEncoderLocalizer(DriveEncoderConstants lConstants) {
-        return setLocalizer(new DriveEncoderLocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new DriveEncoderLocalizer(hardwareMap, lConstants);
+        return this;
     }
 
     public FollowerBuilder octoQuadLocalizer(OctoQuadConstants lConstants, OctoQuadLocalizer.InitMode initMode) {
-        return setLocalizer(new OctoQuadLocalizer(hardwareMap, lConstants, initMode));
+        this.localizerSupplier = () -> new OctoQuadLocalizer(hardwareMap, lConstants, initMode);
+        return this;
     }
 
     public FollowerBuilder OTOSLocalizer(OTOSConstants lConstants) {
-        return setLocalizer(new OTOSLocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new OTOSLocalizer(hardwareMap, lConstants);
+        return this;
     }
 
     public FollowerBuilder pinpointLocalizer(PinpointConstants lConstants) {
-        return setLocalizer(new PinpointLocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new PinpointLocalizer(hardwareMap, lConstants, resetIMU);
+        return this;
     }
 
     public FollowerBuilder threeWheelIMULocalizer(ThreeWheelIMUConstants lConstants) {
-        return setLocalizer(new ThreeWheelIMULocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new ThreeWheelIMULocalizer(hardwareMap, lConstants);
+        return this;
     }
 
     public FollowerBuilder threeWheelLocalizer(ThreeWheelConstants lConstants) {
-        return setLocalizer(new ThreeWheelLocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new ThreeWheelLocalizer(hardwareMap, lConstants);
+        return this;
     }
 
     public FollowerBuilder twoWheelLocalizer(TwoWheelConstants lConstants) {
-        return setLocalizer(new TwoWheelLocalizer(hardwareMap, lConstants));
+        this.localizerSupplier = () -> new TwoWheelLocalizer(hardwareMap, lConstants);
+        return this;
     }
 
     public FollowerBuilder setDrivetrain(Drivetrain drivetrain) {
@@ -96,7 +105,12 @@ public class FollowerBuilder {
         return this;
     }
 
+    public FollowerBuilder resetIMU(boolean resetIMU) {
+        this.resetIMU = resetIMU;
+        return this;
+    }
+
     public Follower build() {
-        return new Follower(constants, localizer, drivetrain, constraints);
+        return new Follower(constants, localizerSupplier.get(), drivetrain, constraints, resetIMU);
     }
 }

--- a/ftc/src/main/java/com/pedropathing/ftc/FollowerBuilder.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/FollowerBuilder.java
@@ -33,7 +33,7 @@ public class FollowerBuilder {
     private final HardwareMap hardwareMap;
     private Supplier<Localizer> localizerSupplier;
     private Drivetrain drivetrain;
-    private boolean resetIMU = true;
+    private boolean resetIMUOnInit = true;
 
     public FollowerBuilder(FollowerConstants constants, HardwareMap hardwareMap) {
         this.constants = constants;
@@ -62,7 +62,7 @@ public class FollowerBuilder {
     }
 
     public FollowerBuilder pinpointLocalizer(PinpointConstants lConstants) {
-        this.localizerSupplier = () -> new PinpointLocalizer(hardwareMap, lConstants, resetIMU);
+        this.localizerSupplier = () -> new PinpointLocalizer(hardwareMap, lConstants, resetIMUOnInit);
         return this;
     }
 
@@ -105,12 +105,12 @@ public class FollowerBuilder {
         return this;
     }
 
-    public FollowerBuilder resetIMU(boolean resetIMU) {
-        this.resetIMU = resetIMU;
+    public FollowerBuilder resetIMUOnInit(boolean resetIMUOnInit) {
+        this.resetIMUOnInit = resetIMUOnInit;
         return this;
     }
 
     public Follower build() {
-        return new Follower(constants, localizerSupplier.get(), drivetrain, constraints, resetIMU);
+        return new Follower(constants, localizerSupplier.get(), drivetrain, constraints, resetIMUOnInit);
     }
 }

--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/PinpointLocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/PinpointLocalizer.java
@@ -44,7 +44,19 @@ public class PinpointLocalizer implements Localizer {
      *
      * @param map the HardwareMap
      */
-    public PinpointLocalizer(HardwareMap map, PinpointConstants constants){ this(map, constants, new Pose());}
+    public PinpointLocalizer(HardwareMap map, PinpointConstants constants) {
+        this(map, constants, true);
+    }
+
+    /**
+     * This creates a new PinpointLocalizer from a HardwareMap, with a starting Pose at (0,0)
+     * facing 0 heading.
+     *
+     * @param map the HardwareMap
+     */
+    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, boolean resetIMU) {
+        this(map, constants, new Pose(), resetIMU);
+    }
 
     /**
      * This creates a new PinpointLocalizer from a HardwareMap and a Pose, with the Pose
@@ -54,7 +66,7 @@ public class PinpointLocalizer implements Localizer {
      * @param setStartPose the Pose to start from
      */
     @SuppressLint("NewApi")
-    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, Pose setStartPose){
+    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, Pose setStartPose, boolean resetIMU) {
 
         odo = map.get(GoBildaPinpointDriver.class,constants.hardwareMapName);
         setOffsets(constants.forwardPodY, constants.strafePodX, constants.distanceUnit);
@@ -71,11 +83,19 @@ public class PinpointLocalizer implements Localizer {
 
         odo.setEncoderDirections(constants.forwardEncoderDirection, constants.strafeEncoderDirection);
 
-        setStartPose(setStartPose);
+        if (resetIMU) {
+            setStartPose(setStartPose);
+            pinpointPose = startPose;
+            previousHeading = setStartPose.getHeading();
+        } else {
+            odo.update();
+            pinpointPose = PoseConverter.pose2DToPose(odo.getPosition(), PedroCoordinates.INSTANCE);
+            startPose = pinpointPose;
+            previousHeading = pinpointPose.getHeading();
+        }
+
         totalHeading = 0;
-        pinpointPose = startPose;
         currentVelocity = new Pose();
-        previousHeading = setStartPose.getHeading();
         this.constants = constants;
     }
 

--- a/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/PinpointLocalizer.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/localization/localizers/PinpointLocalizer.java
@@ -54,8 +54,8 @@ public class PinpointLocalizer implements Localizer {
      *
      * @param map the HardwareMap
      */
-    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, boolean resetIMU) {
-        this(map, constants, new Pose(), resetIMU);
+    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, boolean resetIMUOnInit) {
+        this(map, constants, new Pose(), resetIMUOnInit);
     }
 
     /**
@@ -66,7 +66,7 @@ public class PinpointLocalizer implements Localizer {
      * @param setStartPose the Pose to start from
      */
     @SuppressLint("NewApi")
-    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, Pose setStartPose, boolean resetIMU) {
+    public PinpointLocalizer(HardwareMap map, PinpointConstants constants, Pose setStartPose, boolean resetIMUOnInit) {
 
         odo = map.get(GoBildaPinpointDriver.class,constants.hardwareMapName);
         setOffsets(constants.forwardPodY, constants.strafePodX, constants.distanceUnit);
@@ -83,7 +83,7 @@ public class PinpointLocalizer implements Localizer {
 
         odo.setEncoderDirections(constants.forwardEncoderDirection, constants.strafeEncoderDirection);
 
-        if (resetIMU) {
+        if (resetIMUOnInit) {
             setStartPose(setStartPose);
             pinpointPose = startPose;
             previousHeading = setStartPose.getHeading();


### PR DESCRIPTION
This PR adds an optional `resetIMU` flag to `FollowerBuilder` that controls whether the IMU resets on initialization. When set to false, the IMU doesn't reset, and the robot picks up exactly where it left off.

This is useful for preserving pose between auto and TeleOp, especially for Pinpoint users as the Pinpoint still calculates the position even if the robot moved when no OpMode was active. It is also useful if you have a rotating flywheel that makes vibrations, and resetting the IMU would catch these vibrations.

_Default behavior (resetIMU = true) is unchanged._

**Tested on our robot (23644) and working properly**

# Changes
`FollowerBuilder` now stores localizer construction as a `Supplier<Localizer>` instead of creating the localizer when the localizer method is called. This is necessary because `resetIMU` may be set before or after the localizer method in the builder chain, so the localizer needs to be created at `build()` time when the final value of `resetIMU` is known. The `pinpointLocalizer()` method captures `resetIMU` in the lambda, which is then evaluated in `build()`.

# Usage
To set `resetIMU`, add `.resetIMU(boolean)` to the `FollowerBuilder` inside your `Constants` class. No other changes needed.

```java
new FollowerBuilder(followerConstants, hardwareMap)
        .resetIMU(false)
        .mecanumDrivetrain(driveConstants)
        .pinpointLocalizer(localizerConstants)
        .build();
```