### PR TITLE
Add interactive pose recorder for capturing field coordinates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/ftc/src/main/java/com/pedropathing/ftc/util/PoseRecorder.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/util/PoseRecorder.java
@@ -1,0 +1,172 @@
+package com.pedropathing.ftc.util;
+
+import com.pedropathing.follower.Follower;
+import com.pedropathing.geometry.Pose;
+import com.qualcomm.robotcore.hardware.Gamepad;
+import com.qualcomm.robotcore.util.RobotLog;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A reusable helper for interactively recording robot poses off a {@link Follower}.
+ *
+ * <p>Drop this into any TeleOp OpMode: construct it once with your {@code Follower}, a
+ * {@code Gamepad}, and the OpMode's {@code Telemetry}, then call {@link #update()} every loop
+ * iteration (after {@code follower.update()}). While the OpMode runs you physically drag or
+ * drive the robot around the field and press a button to capture wherever it currently is. Each
+ * captured {@link Pose} is:</p>
+ *
+ * <ul>
+ *     <li>appended to an in-memory list, shown on the Driver Station as a numbered,
+ *     copy-pasteable {@code new Pose(...)} snippet, and</li>
+ *     <li>written to the Robot Controller log via {@link RobotLog}, so it streams to your coding
+ *     computer through {@code adb logcat} (filter tag {@code PoseRecorder}) and is saved to the
+ *     RC log file.</li>
+ * </ul>
+ *
+ * <p>Poses are captured in the follower's native (Pedro) coordinate system, so the emitted
+ * snippets drop straight into path-building code.</p>
+ *
+ * <p>Default button map (all reconfigurable via the setters): <b>A</b> captures the current
+ * pose, <b>B</b> undoes the last capture, and <b>Back + Y</b> clears the whole list (the guard
+ * button avoids wiping your work by accident).</p>
+ *
+ * @author Pedro Pathing
+ */
+public class PoseRecorder {
+    /** A gamepad button, resolved against a {@link Gamepad} each loop for rising-edge detection. */
+    public interface Button {
+        boolean isPressed(Gamepad gamepad);
+    }
+
+    private final Follower follower;
+    private final Gamepad gamepad;
+    private final Telemetry telemetry;
+
+    private final List<Pose> recorded = new ArrayList<>();
+
+    private Button captureButton = g -> g.a;
+    private Button undoButton = g -> g.b;
+    private Button clearButton = g -> g.y;
+    private Button clearGuard = g -> g.back;
+
+    private boolean previousCapture = false;
+    private boolean previousUndo = false;
+    private boolean previousClear = false;
+
+    /**
+     * @param follower  the follower whose current pose will be captured
+     * @param gamepad   the gamepad polled for capture/undo/clear buttons
+     * @param telemetry the OpMode telemetry used to render the live pose and recorded list
+     */
+    public PoseRecorder(Follower follower, Gamepad gamepad, Telemetry telemetry) {
+        this.follower = follower;
+        this.gamepad = gamepad;
+        this.telemetry = telemetry;
+    }
+
+    /** Sets the button that captures the current pose (default {@code A}). */
+    public PoseRecorder setCaptureButton(Button captureButton) {
+        this.captureButton = captureButton;
+        return this;
+    }
+
+    /** Sets the button that removes the most recent capture (default {@code B}). */
+    public PoseRecorder setUndoButton(Button undoButton) {
+        this.undoButton = undoButton;
+        return this;
+    }
+
+    /** Sets the button that clears every capture (default {@code Y}, guarded). */
+    public PoseRecorder setClearButton(Button clearButton) {
+        this.clearButton = clearButton;
+        return this;
+    }
+
+    /**
+     * Sets the guard button that must be held together with the clear button (default
+     * {@code Back}). Pass {@code g -> true} to disable the guard.
+     */
+    public PoseRecorder setClearGuard(Button clearGuard) {
+        this.clearGuard = clearGuard;
+        return this;
+    }
+
+    /**
+     * Polls the gamepad, applies any capture/undo/clear action on the button's rising edge, and
+     * renders telemetry. Call once per loop iteration, after {@code follower.update()}.
+     * Does not call {@code telemetry.update()} — the OpMode owns that.
+     */
+    public void update() {
+        boolean capture = captureButton.isPressed(gamepad);
+        boolean undo = undoButton.isPressed(gamepad);
+        boolean clear = clearButton.isPressed(gamepad) && clearGuard.isPressed(gamepad);
+
+        if (capture && !previousCapture) {
+            capture();
+        }
+        if (undo && !previousUndo) {
+            undo();
+        }
+        if (clear && !previousClear) {
+            clear();
+        }
+
+        previousCapture = capture;
+        previousUndo = undo;
+        previousClear = clear;
+
+        renderTelemetry();
+    }
+
+    /** Captures the follower's current pose and logs it. */
+    public void capture() {
+        Pose pose = follower.getPose().copy();
+        recorded.add(pose);
+        RobotLog.ii("PoseRecorder", "captured #%d: %s", recorded.size(), snippet(pose));
+    }
+
+    /** Removes the most recent capture, if any. */
+    public void undo() {
+        if (!recorded.isEmpty()) {
+            Pose removed = recorded.remove(recorded.size() - 1);
+            RobotLog.ii("PoseRecorder", "undo: removed %s (%d left)", snippet(removed), recorded.size());
+        }
+    }
+
+    /** Removes every capture. */
+    public void clear() {
+        int count = recorded.size();
+        recorded.clear();
+        RobotLog.ii("PoseRecorder", "cleared %d pose(s)", count);
+    }
+
+    /**
+     * Returns a copy of the recorded poses in capture order. Mutating the returned list does not
+     * affect the recorder.
+     */
+    public List<Pose> getRecordedPoses() {
+        return new ArrayList<>(recorded);
+    }
+
+    private void renderTelemetry() {
+        Pose current = follower.getPose();
+        telemetry.addLine("== Pose Recorder ==");
+        telemetry.addData("Current", "x %.2f  y %.2f  heading %.2f°",
+                current.getX(), current.getY(), Math.toDegrees(current.getHeading()));
+        telemetry.addLine("A: capture   B: undo   Back+Y: clear");
+        telemetry.addData("Recorded", recorded.size());
+        for (int i = 0; i < recorded.size(); i++) {
+            telemetry.addLine((i + 1) + ": " + snippet(recorded.get(i)));
+        }
+    }
+
+    /** Formats a pose as a copy-pasteable {@code new Pose(x, y, Math.toRadians(deg))} snippet. */
+    private static String snippet(Pose pose) {
+        return String.format("new Pose(%.3f, %.3f, Math.toRadians(%.2f))",
+                pose.getX(), pose.getY(), Math.toDegrees(pose.getHeading()));
+    }
+}

--- a/ftc/src/main/java/com/pedropathing/ftc/util/PoseRecorderOpMode.java
+++ b/ftc/src/main/java/com/pedropathing/ftc/util/PoseRecorderOpMode.java
@@ -1,0 +1,96 @@
+package com.pedropathing.ftc.util;
+
+import com.pedropathing.follower.Follower;
+import com.pedropathing.geometry.Pose;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+/**
+ * A turnkey base OpMode for recording field coordinates by dragging or driving the robot around.
+ *
+ * <p>Extend this in your TeamCode, add the {@code @TeleOp} annotation, and implement
+ * {@link #createFollower(HardwareMap)} to build your configured {@link Follower}. Optionally
+ * override {@link #startingPose()} to declare, <em>in code</em>, where you physically place the
+ * robot before pressing start. Everything else — teleop driving, gamepad capture, the numbered
+ * Driver Station list, and streaming captures to your computer via {@code adb logcat} — is
+ * handled by {@link PoseRecorder}.</p>
+ *
+ * <pre>{@code
+ * @TeleOp(name = "Pose Recorder")
+ * public class MyPoseRecorder extends PoseRecorderOpMode {
+ *     @Override protected Follower createFollower(HardwareMap h) { return Constants.createFollower(h); }
+ *     @Override protected Pose startingPose() { return new Pose(9, 111, Math.toRadians(90)); }
+ * }
+ * }</pre>
+ *
+ * <p>During the run, drive with the left stick (translate) and right stick (turn), or just push
+ * the robot by hand — the localizer tracks its pose either way. Press <b>A</b> to capture the
+ * current pose, <b>B</b> to undo, and <b>Back + Y</b> to clear.</p>
+ *
+ * @author Pedro Pathing
+ */
+public abstract class PoseRecorderOpMode extends LinearOpMode {
+
+    /**
+     * Builds the configured follower for this robot, typically via {@code FollowerBuilder}.
+     *
+     * @param hardwareMap the OpMode hardware map
+     * @return the follower whose pose will be recorded
+     */
+    protected abstract Follower createFollower(HardwareMap hardwareMap);
+
+    /**
+     * The pose the robot is physically placed at before the OpMode starts. Override to declare
+     * your starting position in code. Defaults to the origin (0, 0, heading 0).
+     *
+     * @return the starting pose
+     */
+    protected Pose startingPose() {
+        return new Pose();
+    }
+
+    /**
+     * Whether to enable gamepad teleop driving. Override to return {@code false} for a purely
+     * hand-dragged workflow with the motors left off. Defaults to {@code true}.
+     *
+     * @return true to enable teleop driving
+     */
+    protected boolean useTeleOpDrive() {
+        return true;
+    }
+
+    @Override
+    public void runOpMode() {
+        Follower follower = createFollower(hardwareMap);
+        // setStartingPose must run before any movement, so it happens here in init.
+        follower.setStartingPose(startingPose());
+
+        PoseRecorder recorder = new PoseRecorder(follower, gamepad1, telemetry);
+
+        telemetry.addLine("Pose Recorder ready. Press start, then drag/drive the robot.");
+        telemetry.addData("Starting pose", startingPose());
+        telemetry.update();
+
+        waitForStart();
+
+        if (useTeleOpDrive()) {
+            follower.startTeleopDrive();
+        }
+
+        while (opModeIsActive()) {
+            if (useTeleOpDrive()) {
+                // Library convention: forward = -left_stick_y, strafe = -left_stick_x,
+                // turn = -right_stick_x. Robot-centric so pushing the robot by hand is unaffected.
+                follower.setTeleOpDrive(
+                        -gamepad1.left_stick_y,
+                        -gamepad1.left_stick_x,
+                        -gamepad1.right_stick_x,
+                        true);
+            }
+
+            follower.update();
+            recorder.update();
+            telemetry.update();
+        }
+    }
+}


### PR DESCRIPTION
By Metal Magic FTC 23362

We added a TeleOp workflow for authoring field coordinates by moving the robot instead of measuring the field by hand. Set a starting pose in code, then drag or drive the robot around the field and press a button to capture the robots current pose. Captures accumulate in a numbered, copy pasteable list on the Driver Station and stream to the coding computer via adb logcat, so they drop straight into path code.

Two new classes in com.pedropathing.ftc.util:
- PoseRecorder: reusable helper taking (follower, gamepad, telemetry). Call update() each loop to detect button rising-edges, capture follower.getPose(), render the live pose + recorded list, and log each capture. Default buttons A/B/Back+Y for capture/undo/clear, all reconfigurable; exposes capture()/undo()/clear()/getRecordedPoses().
- PoseRecorderOpMode: turnkey abstract LinearOpMode. Teams implement createFollower(hardwareMap) and optionally override startingPose() to declare their start position in code. Enables gamepad teleop driving while leaving the robot free to be hand-dragged.

Poses are captured in the follower's native Pedro coordinate frame. Compiles against the existing compileOnly FTC SDK. No build changes.

an example of code (woa i figured out markdown):
```java
@TeleOp(name = "Pose Recorder")
public class MyPoseRecorder extends PoseRecorderOpMode {
    @Override
    protected Follower createFollower(HardwareMap hardwareMap) {
        return Constants.createFollower(hardwareMap); // your normal follower setup
    }

    @Override
    protected Pose startingPose() {
        return new Pose(9, 111, Math.toRadians(90)); // where the robot starts
    }
}
```

on gamepad then: 
A to capture current pose
B to undo last
Back + Y to clear all

Then, on computer, check logcat to get lines u can copy paste like "new Pose(12.000, 34.000, Math.toRadians(90.00))"