### PR TITLE
Fix two inert rolling buffers in VectorCalculator

### DIFF
--- a/core/src/main/java/com/pedropathing/VectorCalculator.java
+++ b/core/src/main/java/com/pedropathing/VectorCalculator.java
@@ -172,8 +172,8 @@ public class VectorCalculator {
      * Do the teleop calculations
      */
     public void teleopUpdate() {
-        velocities.add(velocity);
-        velocities.remove(velocities.get(velocities.size() - 1));
+        velocities.add(0, velocity);
+        velocities.remove(velocities.size() - 1);
 
         calculateAveragedVelocityAndAcceleration();
     }
@@ -430,7 +430,7 @@ public class VectorCalculator {
         }
         averagePreviousVelocity = averagePreviousVelocity.times(1.0 / ((double) velocities.size() / 2));
 
-        accelerations.add(averageVelocity.minus(averagePreviousVelocity));
+        accelerations.add(0, averageVelocity.minus(averagePreviousVelocity));
         accelerations.remove(accelerations.size() - 1);
 
         averageAcceleration = new Vector();

--- a/core/src/main/java/com/pedropathing/VectorCalculator.java
+++ b/core/src/main/java/com/pedropathing/VectorCalculator.java
@@ -153,9 +153,11 @@ public class VectorCalculator {
         correctiveVector = new Vector();
 
         int AVERAGED_VELOCITY_SAMPLE_NUMBER = 8;
+        velocities.clear();
         for (int i = 0; i < AVERAGED_VELOCITY_SAMPLE_NUMBER; i++) {
             velocities.add(new Vector());
         }
+        accelerations.clear();
         for (int i = 0; i < AVERAGED_VELOCITY_SAMPLE_NUMBER / 2; i++) {
             accelerations.add(new Vector());
         }


### PR DESCRIPTION
Fixes #172.

Both rolling buffers in `VectorCalculator` appended a sample and then immediately removed the element they had just appended, so every update was a no-op and both stayed filled with the zero-vectors that `breakFollowing()` seeded them with. The visible effect is that **teleop centripetal force correction has been silently disabled**; autonomous is unaffected.

Three lines changed.

### `teleopUpdate()`

```diff
-        velocities.add(velocity);
-        velocities.remove(velocities.get(velocities.size() - 1));
+        velocities.add(0, velocity);
+        velocities.remove(velocities.size() - 1);
```

After the `add`, index `size() - 1` is the element just appended. `get(...)` returns a `Vector`, so this bound to `List.remove(Object)`, and with no `equals` override on `Vector` the match was by identity — it removed exactly that element.

### `calculateAveragedVelocityAndAcceleration()`

```diff
-        accelerations.add(averageVelocity.minus(averagePreviousVelocity));
+        accelerations.add(0, averageVelocity.minus(averagePreviousVelocity));
         accelerations.remove(accelerations.size() - 1);
```

Same outcome by a different route: here the argument is an `int`, so it bound to `List.remove(int)` and removed the last index, which was again the element just added.

### Why insert at the front

`calculateAveragedVelocityAndAcceleration()` reads indices `[0, n/2)` as the recent half and `[n/2, n)` as the older half, so the buffer is intended to be newest-first. Inserting at index 0 and evicting from the back gives that ordering. For `accelerations` the average is taken over the whole list so insertion position does not change the result, but keeping both buffers to the same convention seemed better than having them differ.

`Pose.getAsVector()` returns a freshly constructed `Vector` on every call, so storing the reference directly is safe and no defensive copy is needed.

### Verification

Reproduction of the original behaviour is in #172. With this change, the same harness driving a robot accelerating forward while drifting sideways produces real curvature where it previously produced `NaN` on every cycle:

```
  step 1: avgV=(  2.50,  0.13)  avgA=(  0.63,  0.03)  curvature=0.012453
  step 2: avgV=(  7.50,  0.62)  avgA=(  2.50,  0.19)  curvature=0.024742
  step 4: avgV=( 25.00,  3.75)  avgA=( 12.50,  1.56)  curvature=0.060448
  step 8: avgV=( 65.00, 21.75)  avgA=( 37.50, 12.19)  curvature=0.159905
```

`core` compiles clean with the change.

### Notes

I kept this to the minimal fix. There is no test source set in `core` today, so adding a regression test would have meant introducing test infrastructure alongside a bug fix — happy to open that as a separate PR if it would be welcome.

Worth flagging that since this correction has been inert, any teleop tuning done so far was done without it. Enabling it may change teleop feel and `centripetalScaling` may want a second look.

Found while reading Pedro as background for a project of my own. Thanks for keeping the source this readable — the bug was findable precisely because the code is clear.
